### PR TITLE
fixed EPIPE error when launching VSCode

### DIFF
--- a/package/contents/ui/DashboardRepresentation.qml
+++ b/package/contents/ui/DashboardRepresentation.qml
@@ -691,7 +691,7 @@ Kicker.DashboardWindow {
             var stem = df.replace(/\.desktop$/i, "");
             if (!stem) return;
             var quoted = "'" + stem.replace(/'/g, "'\\''") + "'";
-            dashLauncher.connectSource("gtk-launch " + quoted + " #" + Date.now());
+            dashLauncher.connectSource("nohup gtk-launch " + quoted + " >/dev/null 2>&1 &");
         }
 
         function addToDashboard(desktopFile, name, icon) {


### PR DESCRIPTION
When I use Linexin-Launcher to start VSCode:
<img width="1093" height="931" alt="图片" src="https://github.com/user-attachments/assets/ad39c85c-d4f9-46bd-8380-32a4f4bbbb72" />

AI Agent located the bug and implemented a fix.It works.
[AI Agent Assistant.md](https://github.com/user-attachments/files/27229069/AI.Agent.Assistant.md)
